### PR TITLE
Add alternative installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,3 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
+*idea
 /build/
 /cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   	add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+find_package(Franka 0.7.0 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(cppzmq REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,67 @@ so be sure to select that have an associated RT patch available.
 
 ## Installation
 
+First, you need to install libZMQ with C++ bindings, which in turn depends on libsodium and libzmq3.
+
+```bash
+sudo apt-get update && sudo apt-get install -y \
+  libsodium-dev \
+  libzmq3-dev
+
+# install cppzmq bindings
+wget https://github.com/zeromq/cppzmq/archive/v4.7.1.tar.gz -O cppzmq-4.7.1.tar.gz
+tar -xzf cppzmq-4.7.1.tar.gz
+cd cppzmq-4.7.1
+mkdir build
+cd build
+cmake .. -DCPPZMQ_BUILD_TESTS=OFF
+sudo make -j4 install
+cd ../..
+rm -rf cppzmq*
+```
+
+Then, depending on your needs, continue [here](#libfranka-is-installed-somewhere-else-on-the-computer) if `libfranka`
+has already been installed somewhere else on the computer, or [here](#install-libfranka-as-submodule) if you want to
+install `libfranka` alongside the `franka_lightweight_interface`.
+
+### `libfranka` is installed somewhere else on the computer
+
+If `libfranka` has already been installed on the computer, following the steps of
+the [documentation](https://frankaemika.github.io/docs/installation_linux.html)
+
+```bash
+sudo apt install build-essential cmake git libpoco-dev libeigen3-dev
+git clone --recursive https://github.com/frankaemika/libfranka
+cd libfranka
+git checkout <version>
+git submodule update
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+```
+
+go back to the `build` directory of `libfranka` again and run
+
+```bash
+make -j && sudo make install && sudo ldconfig
+```
+
+This will enable `franka_lightweight_interface` to find the headers of `libfranka`. Finally, clone this repository
+without the submodule option:
+
+```bash
+git clone https://github.com/epfl-lasa/franka_lightweight_interface.git
+```
+
+of for ssh cloning:
+
+```bash
+git clone git@github.com:epfl-lasa/franka_lightweight_interface.git
+```
+
+### Install `libfranka` as submodule
+
 To install this library, first clone the repository with the recursive option to
 download [libfranka](https://frankaemika.github.io/docs/libfranka.html), added as a submodule:
 
@@ -47,24 +108,7 @@ Then build and install the library
 cd lib/libfranka && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j && sudo make install && sudo ldconfig
 ```
 
-You also need to install libZMQ with C++ bindings, which in turn depends on libsodium and libzmq3.
-
-```bash
-sudo apt-get update && sudo apt-get install -y \
-  libsodium-dev \
-  libzmq3-dev
-
-# install cppzmq bindings
-wget https://github.com/zeromq/cppzmq/archive/v4.7.1.tar.gz -O cppzmq-4.7.1.tar.gz
-tar -xzf cppzmq-4.7.1.tar.gz
-cd cppzmq-4.7.1
-mkdir build
-cd build
-cmake .. -DCPPZMQ_BUILD_TESTS=OFF
-sudo make -j4 install
-cd ../..
-rm -rf cppzmq*
-```
+### Build the interface
 
 Finally build the interface with:
 


### PR DESCRIPTION
I improved the README a bit, to explain how to install the lwi if libfranka is somewhere else on the system. Also the installation instructions for libfranka are incomplete because they dont do
```bash
make -j && sudo make install && sudo ldconfig
```