### PR TITLE
Add ControlType to protocol and interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
+project(franka_lightweight_interface VERSION 1.1)
 
 # Options. Turn on with 'cmake -Druntests=ON'.
 option(runtests "Build all tests." OFF) # Makes boolean 'test' available.
 
-project(franka_lightweight_interface)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)

--- a/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
+++ b/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
@@ -36,6 +36,7 @@ private:
   zmq::socket_t zmq_subscriber_;
   proto::CommandMessage<7> zmq_command_msg_{};
   proto::StateMessage<7> zmq_state_msg_{};
+  proto::ControlType control_type_ = proto::NONE;
   Eigen::Vector3d current_cartesian_position_;
   Eigen::Quaterniond current_cartesian_orientation_;
   Eigen::Matrix<double, 6, 1> current_cartesian_twist_;
@@ -45,7 +46,13 @@ private:
   Eigen::Matrix<double, 7, 1> current_joint_torques_;
   Eigen::Matrix<double, 6, 7> current_jacobian_;
   Eigen::Matrix<double, 7, 7> current_mass_;
+  Eigen::Matrix<double, 7, 1> command_joint_positions_;
+  Eigen::Matrix<double, 7, 1> command_joint_velocities_;
   Eigen::Matrix<double, 7, 1> command_joint_torques_;
+  Eigen::Vector3d command_cartesian_position_;
+  Eigen::Quaterniond command_cartesian_orientation_;
+  Eigen::Matrix<double, 6, 1> command_cartesian_twist_;
+  Eigen::Matrix<double, 6, 1> command_cartesian_wrench_;
   std::chrono::steady_clock::time_point last_command_;
   std::chrono::milliseconds command_timeout_ = std::chrono::milliseconds(500);
   std::mutex mutex_;
@@ -108,10 +115,21 @@ public:
   void read_robot_state(const franka::RobotState& robot_state);
 
   /**
+   * @brief Read and publish the robot state while no control commands are received
+   */
+  void run_state_publisher();
+
+  /**
    * @brief Run the joint torques controller
    * that reads commands from the joint torques subscription
    */
   void run_joint_torques_controller();
+
+  /**
+   * @brief Run the Cartesian velocities controller
+   * that reads commands from the cartesian twist subscription
+   */
+  void run_cartesian_velocities_controller();
 
 };
 

--- a/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
+++ b/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
@@ -30,7 +30,7 @@ struct Joints {
 struct Vec3D {
   Vec3D() : x(0), y(0), z(0) {}
   explicit Vec3D(std::array<datatype, 3> vec) : x(vec[0]), y(vec[1]), z(vec[2]) {}
-  inline std::array<datatype, 3> data() { return std::array<datatype, 3>({x, y, z}); }
+  inline std::array<datatype, 3> data() const { return std::array<datatype, 3>({x, y, z}); }
   datatype x;
   datatype y;
   datatype z;
@@ -40,7 +40,7 @@ struct Vec3D {
 struct Quaternion {
   Quaternion() : w(0), x(0), y(0), z(0) {}
   explicit Quaternion(std::array<datatype, 4> q) : w(q[0]), x(q[1]), y(q[2]), z(q[3]) {}
-  inline std::array<datatype, 4> data() { return std::array<datatype, 4>({w, x, y, z}); }
+  inline std::array<datatype, 4> data() const { return std::array<datatype, 4>({w, x, y, z}); }
   datatype w;
   datatype x;
   datatype y;
@@ -51,7 +51,7 @@ struct EEPose {
   EEPose() : position(), orientation() {}
   explicit EEPose(std::array<datatype, 7> pose) : position({pose[0], pose[1], pose[2]}),
                                                   orientation({pose[3], pose[4], pose[5], pose[6]}) {}
-  inline std::array<datatype, 7> data() {
+  inline std::array<datatype, 7> data() const {
     return std::array<datatype, 7>({
       position.x, position.y, position.z, orientation.w, orientation.x, orientation.y, orientation.z
     });
@@ -64,7 +64,7 @@ struct EETwist {
   EETwist() : linear(), angular() {}
   explicit EETwist(std::array<datatype, 6> twist) : linear({twist[0], twist[1], twist[2]}),
                                                     angular({twist[3], twist[4], twist[5]}) {}
-  inline std::array<datatype, 6> data() {
+  inline std::array<datatype, 6> data() const {
     return std::array<datatype, 6>({
       linear.x, linear.y, linear.z, angular.x, angular.y, angular.z
     });

--- a/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
+++ b/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
@@ -9,13 +9,7 @@ namespace frankalwi::proto {
 typedef double datatype;
 
 enum ControlType {
-  NONE = 0,
-  JOINT_POSITION,
-  JOINT_VELOCITY,
-  JOINT_TORQUE,
-  CARTESIAN_POSE,
-  CARTESIAN_TWIST,
-  CARTESIAN_WRENCH
+  NONE = 0, JOINT_POSITION, JOINT_VELOCITY, JOINT_TORQUE, CARTESIAN_POSE, CARTESIAN_TWIST, CARTESIAN_WRENCH
 };
 
 // --- Message sub-structures --- //
@@ -51,12 +45,13 @@ struct Quaternion {
 
 struct EEPose {
   EEPose() : position(), orientation() {}
-  explicit EEPose(std::array<datatype, 7> pose) : position({pose[0], pose[1], pose[2]}),
-                                                  orientation({pose[3], pose[4], pose[5], pose[6]}) {}
+  explicit EEPose(std::array<datatype, 7> pose) :
+      position({pose[0], pose[1], pose[2]}), orientation({pose[3], pose[4], pose[5], pose[6]}) {}
   inline std::array<datatype, 7> array() const {
     return std::array<datatype, 7>({
-      position.x, position.y, position.z, orientation.w, orientation.x, orientation.y, orientation.z
-    });
+                                       position.x, position.y, position.z, orientation.w, orientation.x, orientation.y,
+                                       orientation.z
+                                   });
   }
   Vec3D position;
   Quaternion orientation;
@@ -64,12 +59,12 @@ struct EEPose {
 
 struct EETwist {
   EETwist() : linear(), angular() {}
-  explicit EETwist(std::array<datatype, 6> twist) : linear({twist[0], twist[1], twist[2]}),
-                                                    angular({twist[3], twist[4], twist[5]}) {}
+  explicit EETwist(std::array<datatype, 6> twist) :
+      linear({twist[0], twist[1], twist[2]}), angular({twist[3], twist[4], twist[5]}) {}
   inline std::array<datatype, 6> array() const {
     return std::array<datatype, 6>({
-      linear.x, linear.y, linear.z, angular.x, angular.y, angular.z
-    });
+                                       linear.x, linear.y, linear.z, angular.x, angular.y, angular.z
+                                   });
   }
   Vec3D linear;
   Vec3D angular;
@@ -79,11 +74,9 @@ struct EETwist {
 // (index = row + column * nrows), and (row = index % nrows), (column = floor(index / nrows))
 // For a 6x7 matrix, the serial indices   0,      1,      2     ...  6,      7,      8 ...
 //   map to the row/column indices as:   [0][0], [1][0], [2][0] ... [0][1], [1][1], [2][1] ...
-template<std::size_t DOF>
-using Jacobian = std::array<datatype, 6 * DOF>;
+template<std::size_t DOF> using Jacobian = std::array<datatype, 6 * DOF>;
 
-template<std::size_t DOF>
-using Mass = std::array<datatype, DOF * DOF>;
+template<std::size_t DOF> using Mass = std::array<datatype, DOF * DOF>;
 
 
 // --- Message structures --- //
@@ -109,3 +102,5 @@ struct CommandMessage {
   EETwist eeTwist;
   EETwist eeWrench;
 };
+
+}

--- a/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
+++ b/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
@@ -24,13 +24,14 @@ struct Joints {
   datatype& operator[](std::size_t i) {
     return data[i % DOF];
   }
+  inline std::array<datatype, DOF> array() const { return data; };
   std::array<datatype, DOF> data;
 };
 
 struct Vec3D {
   Vec3D() : x(0), y(0), z(0) {}
   explicit Vec3D(std::array<datatype, 3> vec) : x(vec[0]), y(vec[1]), z(vec[2]) {}
-  inline std::array<datatype, 3> data() const { return std::array<datatype, 3>({x, y, z}); }
+  inline std::array<datatype, 3> array() const { return std::array<datatype, 3>({x, y, z}); }
   datatype x;
   datatype y;
   datatype z;
@@ -40,7 +41,8 @@ struct Vec3D {
 struct Quaternion {
   Quaternion() : w(0), x(0), y(0), z(0) {}
   explicit Quaternion(std::array<datatype, 4> q) : w(q[0]), x(q[1]), y(q[2]), z(q[3]) {}
-  inline std::array<datatype, 4> data() const { return std::array<datatype, 4>({w, x, y, z}); }
+  inline std::array<datatype, 4> array() const { return std::array<datatype, 4>({w, x, y, z}); }
+  inline std::array<datatype, 4> array_xyzw() const { return std::array<datatype, 4>({x, y, z, w}); }
   datatype w;
   datatype x;
   datatype y;
@@ -51,7 +53,7 @@ struct EEPose {
   EEPose() : position(), orientation() {}
   explicit EEPose(std::array<datatype, 7> pose) : position({pose[0], pose[1], pose[2]}),
                                                   orientation({pose[3], pose[4], pose[5], pose[6]}) {}
-  inline std::array<datatype, 7> data() const {
+  inline std::array<datatype, 7> array() const {
     return std::array<datatype, 7>({
       position.x, position.y, position.z, orientation.w, orientation.x, orientation.y, orientation.z
     });
@@ -64,7 +66,7 @@ struct EETwist {
   EETwist() : linear(), angular() {}
   explicit EETwist(std::array<datatype, 6> twist) : linear({twist[0], twist[1], twist[2]}),
                                                     angular({twist[3], twist[4], twist[5]}) {}
-  inline std::array<datatype, 6> data() const {
+  inline std::array<datatype, 6> array() const {
     return std::array<datatype, 6>({
       linear.x, linear.y, linear.z, angular.x, angular.y, angular.z
     });
@@ -107,16 +109,3 @@ struct CommandMessage {
   EETwist eeTwist;
   EETwist eeWrench;
 };
-
-// --- Conversion helpers --- //
-[[deprecated("Use Vec3D::data() instead")]]
-inline std::array<datatype, 3> vec3DToArray(const Vec3D& vec3D) {
-  return std::array<datatype, 3>({vec3D.x, vec3D.y, vec3D.z});
-}
-
-[[deprecated("Use Quaternion::data() instead")]]
-inline std::array<datatype, 4> quaternionToArray(const Quaternion& quaternion) {
-  return std::array<datatype, 4>({quaternion.w, quaternion.x, quaternion.y, quaternion.z});
-}
-
-}

--- a/src/FrankaLightWeightInterface.cpp
+++ b/src/FrankaLightWeightInterface.cpp
@@ -88,16 +88,16 @@ void FrankaLightWeightInterface::poll_external_command() {
     this->last_command_ = std::chrono::steady_clock::now();
     this->control_type_ = this->zmq_command_msg_.controlType;
 
-    this->command_joint_positions_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointPosition.data.data(), 7, 1);
-    this->command_joint_velocities_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointVelocity.data.data(), 7, 1);
-    this->command_joint_torques_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointTorque.data.data(), 7, 1);
+    this->command_joint_positions_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointPosition.array().data(), 7, 1);
+    this->command_joint_velocities_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointVelocity.array().data(), 7, 1);
+    this->command_joint_torques_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointTorque.array().data(), 7, 1);
 
-    this->command_cartesian_position_ = Eigen::Vector3d(this->zmq_command_msg_.eePose.position.data().data());
-    this->command_cartesian_orientation_ = Eigen::Quaterniond(this->zmq_command_msg_.eePose.orientation.data().data());
-    this->command_cartesian_twist_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.linear.data().data());
-    this->command_cartesian_twist_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.angular.data().data());
-    this->command_cartesian_wrench_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.linear.data().data());
-    this->command_cartesian_wrench_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.angular.data().data());
+    this->command_cartesian_position_ = Eigen::Vector3d(this->zmq_command_msg_.eePose.position.array().data());
+    this->command_cartesian_orientation_ = Eigen::Quaterniond(this->zmq_command_msg_.eePose.orientation.array_xyzw().data());
+    this->command_cartesian_twist_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.linear.array().data());
+    this->command_cartesian_twist_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.angular.array().data());
+    this->command_cartesian_wrench_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.linear.array().data());
+    this->command_cartesian_wrench_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.angular.array().data());
   } else if (std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - this->last_command_).count() > this->command_timeout_.count()) {
     this->command_joint_velocities_.setZero();

--- a/src/FrankaLightWeightInterface.cpp
+++ b/src/FrankaLightWeightInterface.cpp
@@ -2,6 +2,11 @@
 
 #include <utility>
 
+class IncompatibleControlTypeException : public std::runtime_error {
+public:
+  explicit IncompatibleControlTypeException(const std::string& msg) : runtime_error(msg) {};
+};
+
 namespace frankalwi {
 FrankaLightWeightInterface::FrankaLightWeightInterface(std::string robot_ip,
                                                        std::string state_uri,
@@ -44,9 +49,24 @@ void FrankaLightWeightInterface::run_controller() {
   if (this->is_connected()) {
     // restart the controller unless the node is shutdown
     while (!this->is_shutdown()) {
-      std::cout << "Starting controller..." << std::endl;
       try {
-        this->run_joint_torques_controller();
+        switch (this->control_type_) {
+          case proto::JOINT_TORQUE:
+            std::cout << "Starting joint torque controller..." << std::endl;
+            this->run_joint_torques_controller();
+            break;
+          case proto::CARTESIAN_TWIST:
+            std::cout << "Starting cartesian velocities controller..." << std::endl;
+            this->run_cartesian_velocities_controller();
+            break;
+          default:
+            std::cout << "Unimplemented control type! (" << this->control_type_ << ")" << std::endl;
+            [[fallthrough]];
+          case proto::NONE:
+            std::cout << "Starting state publisher..." << std::endl;
+            this->run_state_publisher();
+            break;
+        }
       }
       catch (const franka::CommandException& e) {
         std::cerr << e.what() << std::endl;
@@ -55,6 +75,7 @@ void FrankaLightWeightInterface::run_controller() {
       //flush and reset any remaining command messages
       poll(this->zmq_command_msg_);
       this->command_joint_torques_.setZero();
+      this->command_cartesian_twist_.setZero();
       std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   } else {
@@ -64,11 +85,25 @@ void FrankaLightWeightInterface::run_controller() {
 
 void FrankaLightWeightInterface::poll_external_command() {
   if (poll(this->zmq_command_msg_)) {
-    this->command_joint_torques_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointTorque.data.data(), 7, 1);
     this->last_command_ = std::chrono::steady_clock::now();
+    this->control_type_ = this->zmq_command_msg_.controlType;
+
+    this->command_joint_positions_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointPosition.data.data(), 7, 1);
+    this->command_joint_velocities_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointVelocity.data.data(), 7, 1);
+    this->command_joint_torques_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointTorque.data.data(), 7, 1);
+
+    this->command_cartesian_position_ = Eigen::Vector3d(this->zmq_command_msg_.eePose.position.data().data());
+    this->command_cartesian_orientation_ = Eigen::Quaterniond(this->zmq_command_msg_.eePose.orientation.data().data());
+    this->command_cartesian_twist_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.linear.data().data());
+    this->command_cartesian_twist_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.angular.data().data());
+    this->command_cartesian_wrench_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.linear.data().data());
+    this->command_cartesian_wrench_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.angular.data().data());
   } else if (std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - this->last_command_).count() > this->command_timeout_.count()) {
+    this->command_joint_velocities_.setZero();
     this->command_joint_torques_.setZero();
+    this->command_cartesian_twist_.setZero();
+    this->command_cartesian_wrench_.setZero();
   }
 }
 
@@ -118,8 +153,25 @@ void FrankaLightWeightInterface::read_robot_state(const franka::RobotState& robo
 
   // get the twist from jacobian and current joint velocities
   this->current_cartesian_twist_ = this->current_jacobian_ * this->current_joint_velocities_;
+}
 
-//  this->print_state();
+
+void FrankaLightWeightInterface::run_state_publisher() {
+  try {
+    this->franka_robot_->read([this](const franka::RobotState& robot_state) {
+      // check the local socket for a command
+      this->poll_external_command();
+      if (this->control_type_ != proto::NONE) {
+        std::cout << "Received a new control type command - switching! " << std::endl;
+        return false;
+      }
+      this->read_robot_state(robot_state);
+      this->publish_robot_state();
+      return true;
+    });
+  } catch (const franka::Exception& e) {
+    std::cerr << e.what() << std::endl;
+  }
 }
 
 void FrankaLightWeightInterface::run_joint_torques_controller() {
@@ -140,6 +192,10 @@ void FrankaLightWeightInterface::run_joint_torques_controller() {
                                                  franka::Duration) -> franka::Torques {
       // check the local socket for a torque command
       this->poll_external_command();
+
+      if (this->control_type_ != proto::JOINT_TORQUE) {
+        throw IncompatibleControlTypeException("Control type changed!");
+      }
 
       // lock mutex
       std::lock_guard<std::mutex> lock(this->get_mutex());
@@ -165,6 +221,46 @@ void FrankaLightWeightInterface::run_joint_torques_controller() {
       //return torques;
       return torques;
     });
+  }
+  catch (const franka::Exception& e) {
+    std::cerr << e.what() << std::endl;
+  }
+}
+
+void FrankaLightWeightInterface::run_cartesian_velocities_controller() {
+  // Set additional parameters always before the control loop, NEVER in the control loop!
+
+  this->franka_robot_->setCartesianImpedance({{100, 100, 100, 10, 10, 10}});
+
+  // Set collision behavior.
+  this->franka_robot_->setCollisionBehavior(
+      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
+      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}});
+
+  try {
+    this->franka_robot_->control([this](const franka::RobotState& robot_state,
+                                                 franka::Duration) -> franka::CartesianVelocities {
+      // check the local socket for a velocity command
+      this->poll_external_command();
+
+      if (this->control_type_ != proto::CARTESIAN_TWIST) {
+        throw IncompatibleControlTypeException("Control type changed!");
+      }
+
+      // lock mutex
+      std::lock_guard<std::mutex> lock(this->get_mutex());
+      // extract current state
+      this->read_robot_state(robot_state);
+
+      std::array<double, 6> velocities{};
+      Eigen::VectorXd::Map(&velocities[0], 6) = this->command_cartesian_twist_.array();
+
+      // write the state out to the local socket
+      this->publish_robot_state();
+      return velocities;
+    }, franka::ControllerMode::kCartesianImpedance, true, 10.0);
   }
   catch (const franka::Exception& e) {
     std::cerr << e.what() << std::endl;


### PR DESCRIPTION
* Add ControlType enum to communication protocol
header, with NONE = 0 and types for joint or
cartesian position, velocity or force control.
Not all control types are implemented, but
the types are defined already and reserved
for future use.

* Add helper data() access functions to
Vec3D, Quaternion, EEPose, EETwist structs
to return a std array. Mark conversion
helpers as deprecated.

* Add more command members to the
interface to capture all potential command
types.

* Add state logic to interface to switch
controller based on control type.

* Add run_state_publisher default "controller"
that publishes state data and runs when the
control type is NONE or unimplemented.

* Add run_cartesian_velocities_controller that
uses the Franka cartesian impedance controller
with a twist command.

* Add project version 1.1 in CMakeList, and define
FRANKA_LWI_PROTO_VERSION 1.1 in header

---

Here's just a general improvement that will let us play with more control types on the Franka. This was tested and works fine with the robot in normal joint torque mode, as long as the client updates their franka_lwI_proto header to match the right version and sets the command type accordingly. The cartesian velocity control also technically works, but the Franka controller is very sensitive to jerk / rate change in the signal. You have to start the command with 0 velocity and avoid rapid step changes.

I was thinking about also adding control libraries state_representation as a dependency, so that these added members "pose, orientation, twist, wrench" could be replaced with a single CartesianState for both state and command. But, I think that's not really pressing and I didn't want to bloat the PR.
