### PR TITLE
Refactor frankalwi to use clproto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(Franka 0.7.0 REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(cppzmq REQUIRED)
+find_library(protobuf REQUIRED)
+find_library(clproto REQUIRED)
+find_library(state_representation REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include_directories(
  	include
  	${Eigen3_INCLUDE_DIRS}
+	/usr/local/include/eigen3/
 )
 
 set(CORE_SOURCES
@@ -32,12 +36,12 @@ set(CORE_SOURCES
     src/main.cpp
 )
 
-add_executable (${PROJECT_NAME} ${CORE_SOURCES})
+add_executable(${PROJECT_NAME} ${CORE_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} franka Eigen3::Eigen cppzmq)
+target_link_libraries(${PROJECT_NAME} franka protobuf clproto state_representation cppzmq)
 
-install(DIRECTORY include/
-  	DESTINATION include
+install(DIRECTORY include/frankalwi_proto/
+  	DESTINATION include/frankalwi_proto
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/include/frankalwi_proto/frankalwi_network.h
+++ b/include/frankalwi_proto/frankalwi_network.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <zmq.hpp>
+
+#include "frankalwi_proto.h"
+
+namespace frankalwi::network {
+
+// --- Transceiving methods --- //
+inline bool send(const proto::StateMessage& state, zmq::socket_t& publisher) {
+  auto encoded_message = proto::encode_state(state);
+  zmq::message_t message(sizeof(proto::EncodedStateMessage));
+  memcpy(message.data(), &encoded_message, sizeof(encoded_message));
+  auto res = publisher.send(message, zmq::send_flags::none);
+
+  return res.has_value();
+}
+
+inline bool poll(proto::CommandMessage& command, zmq::socket_t& subscriber) {
+  zmq::message_t message;
+  auto res = subscriber.recv(message, zmq::recv_flags::dontwait);
+  if (res) {
+    auto encoded_command = *message.data<proto::EncodedCommandMessage>();
+    command = proto::decode_command(encoded_command);
+  }
+  return res.has_value();
+}
+
+}

--- a/include/frankalwi_proto/frankalwi_proto.h
+++ b/include/frankalwi_proto/frankalwi_proto.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <clproto.h>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/JointState.hpp>
+#include <state_representation/robot/Jacobian.hpp>
+#include <state_representation/parameters/Parameter.hpp>
+
+namespace frankalwi::proto {
+
+// --- Message structures --- //
+enum ControlType {
+  NONE = 0, JOINT_POSITION, JOINT_VELOCITY, JOINT_TORQUE, CARTESIAN_POSE, CARTESIAN_TWIST, CARTESIAN_WRENCH
+};
+
+struct StateMessage {
+  state_representation::CartesianState ee_state;
+  state_representation::JointState joint_state;
+  state_representation::Jacobian jacobian;
+  Eigen::MatrixXd mass;
+};
+
+struct CommandMessage {
+  ControlType control_type = NONE;
+  state_representation::CartesianState ee_state;
+  state_representation::JointState joint_state;
+};
+
+// --- Encoded message structures --- //
+struct EncodedStateMessage {
+  std::string ee_state;
+  std::string joint_state;
+  std::string jacobian;
+  std::string mass;
+};
+
+struct EncodedCommandMessage {
+  std::string control_type;
+  std::string ee_state;
+  std::string joint_state;
+};
+
+// --- Encoding methods --- //
+inline EncodedStateMessage encode_state(const StateMessage& state) {
+  EncodedStateMessage message;
+  message.ee_state = clproto::encode(state.ee_state);
+  message.joint_state = clproto::encode(state.joint_state);
+  message.jacobian = clproto::encode(state.jacobian);
+  message.mass = clproto::encode(state_representation::Parameter("mass", state.mass));
+  return message;
+}
+
+inline EncodedCommandMessage encode_command(const CommandMessage& command) {
+  EncodedCommandMessage message;
+  message.control_type = clproto::encode(
+      state_representation::Parameter<double>("control_type", static_cast<double>(command.control_type)));
+  message.ee_state = clproto::encode(command.ee_state);
+  message.joint_state = clproto::encode(command.joint_state);
+  return message;
+}
+
+// --- Decoding methods --- //
+inline StateMessage decode_state(const EncodedStateMessage& message) {
+  StateMessage state;
+  state.ee_state = clproto::decode<state_representation::CartesianState>(message.ee_state);
+  state.joint_state = clproto::decode<state_representation::JointState>(message.joint_state);
+  state.jacobian = clproto::decode<state_representation::Jacobian>(message.jacobian);
+  state.mass = clproto::decode<state_representation::Parameter<Eigen::MatrixXd>>(message.mass).get_value();
+  return state;
+}
+
+inline CommandMessage decode_command(const EncodedCommandMessage& message) {
+  CommandMessage command;
+  command.control_type = static_cast<ControlType>(clproto::decode<state_representation::Parameter<double>>(
+      message.control_type).get_value());
+  command.ee_state = clproto::decode<state_representation::CartesianState>(message.ee_state);
+  command.joint_state = clproto::decode<state_representation::JointState>(message.joint_state);
+  return command;
+}
+
+}

--- a/src/FrankaLightWeightInterface.cpp
+++ b/src/FrankaLightWeightInterface.cpp
@@ -1,22 +1,29 @@
 #include "franka_lightweight_interface/FrankaLightWeightInterface.hpp"
 
-#include <utility>
-
 class IncompatibleControlTypeException : public std::runtime_error {
 public:
   explicit IncompatibleControlTypeException(const std::string& msg) : runtime_error(msg) {};
 };
 
 namespace frankalwi {
-FrankaLightWeightInterface::FrankaLightWeightInterface(std::string robot_ip,
-                                                       std::string state_uri,
-                                                       std::string command_uri) :
+
+static CollisionBehaviour default_collision_behaviour() {
+  return {{{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+          {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+          {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
+          {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}};
+}
+
+FrankaLightWeightInterface::FrankaLightWeightInterface(
+    std::string robot_ip, std::string state_uri, std::string command_uri
+) :
     robot_ip_(std::move(robot_ip)),
     connected_(false),
     shutdown_(false),
     state_uri_(std::move(state_uri)),
     command_uri_(std::move(command_uri)),
-    zmq_context_(1) {
+    zmq_context_(1),
+    collision_behaviour_(default_collision_behaviour()) {
 }
 
 void FrankaLightWeightInterface::init() {
@@ -35,14 +42,47 @@ void FrankaLightWeightInterface::init() {
   this->zmq_subscriber_.set(zmq::sockopt::subscribe, "");
   this->zmq_subscriber_.connect("tcp://" + this->command_uri_);
 
-  this->current_cartesian_twist_.setZero();
-  this->current_cartesian_wrench_.setZero();
-  this->current_joint_positions_.setZero();
-  this->current_joint_velocities_.setZero();
-  this->current_joint_torques_.setZero();
-  this->command_joint_torques_.setZero();
+  this->state_.ee_state = state_representation::CartesianState("franka_ee", "franka_base");
+  this->state_.joint_state = state_representation::JointState("franka", 7);
+  this->state_.jacobian = state_representation::Jacobian("franka", 7, "franka_ee", "franka_base");
+  this->state_.mass = Eigen::MatrixXd::Zero(7, 7);
+
+  this->command_.control_type = proto::ControlType::NONE;
+  this->command_.ee_state = state_representation::CartesianState("franka_ee", "franka_base");
+  this->command_.joint_state = state_representation::JointState("franka", 7);
 
   this->last_command_ = std::chrono::steady_clock::now();
+}
+
+void FrankaLightWeightInterface::reset_command() {
+  this->command_.ee_state.set_twist(Eigen::VectorXd::Zero(6));
+  this->command_.ee_state.set_accelerations(Eigen::VectorXd::Zero(6));
+  this->command_.ee_state.set_wrench(Eigen::VectorXd::Zero(6));
+  this->command_.joint_state.set_velocities(Eigen::VectorXd::Zero(7));
+  this->command_.joint_state.set_accelerations(Eigen::VectorXd::Zero(7));
+  this->command_.joint_state.set_torques(Eigen::VectorXd::Zero(7));
+}
+
+void FrankaLightWeightInterface::set_collision_behaviour(
+    const std::array<double, 7>& lower_torque_thresholds_acceleration,
+    const std::array<double, 7>& upper_torque_thresholds_acceleration,
+    const std::array<double, 7>& lower_torque_thresholds_nominal,
+    const std::array<double, 7>& upper_torque_thresholds_nominal,
+    const std::array<double, 6>& lower_force_thresholds_acceleration,
+    const std::array<double, 6>& upper_force_thresholds_acceleration,
+    const std::array<double, 6>& lower_force_thresholds_nominal,
+    const std::array<double, 6>& upper_force_thresholds_nominal
+) {
+  this->set_collision_behaviour(
+      {
+          lower_torque_thresholds_acceleration, upper_torque_thresholds_acceleration, lower_torque_thresholds_nominal,
+          upper_torque_thresholds_nominal, lower_force_thresholds_acceleration, upper_force_thresholds_acceleration,
+          lower_force_thresholds_nominal, upper_force_thresholds_nominal
+      });
+}
+
+void FrankaLightWeightInterface::set_collision_behaviour(const CollisionBehaviour& collision_behaviour) {
+  this->collision_behaviour_ = collision_behaviour;
 }
 
 void FrankaLightWeightInterface::run_controller() {
@@ -50,32 +90,31 @@ void FrankaLightWeightInterface::run_controller() {
     // restart the controller unless the node is shutdown
     while (!this->is_shutdown()) {
       try {
-        switch (this->control_type_) {
-          case proto::JOINT_TORQUE:
+        switch (this->command_.control_type) {
+          case proto::ControlType::JOINT_TORQUE:
             std::cout << "Starting joint torque controller..." << std::endl;
             this->run_joint_torques_controller();
             break;
-          case proto::CARTESIAN_TWIST:
+          case proto::ControlType::CARTESIAN_TWIST:
             std::cout << "Starting cartesian velocities controller..." << std::endl;
             this->run_cartesian_velocities_controller();
             break;
           default:
-            std::cout << "Unimplemented control type! (" << this->control_type_ << ")" << std::endl;
+            std::cout << "Unimplemented control type! (" << this->command_.control_type << ")" << std::endl;
+            this->command_.control_type = proto::ControlType::NONE;
             [[fallthrough]];
-          case proto::NONE:
+          case proto::ControlType::NONE:
             std::cout << "Starting state publisher..." << std::endl;
             this->run_state_publisher();
             break;
         }
-      }
-      catch (const franka::CommandException& e) {
+      } catch (const franka::CommandException& e) {
         std::cerr << e.what() << std::endl;
       }
       std::cerr << "Controller stopped but the node is still active, restarting..." << std::endl;
       //flush and reset any remaining command messages
-      poll(this->zmq_command_msg_);
-      this->command_joint_torques_.setZero();
-      this->command_cartesian_twist_.setZero();
+      network::poll(this->command_, this->zmq_subscriber_);
+      this->reset_command();
       std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   } else {
@@ -84,91 +123,55 @@ void FrankaLightWeightInterface::run_controller() {
 }
 
 void FrankaLightWeightInterface::poll_external_command() {
-  if (poll(this->zmq_command_msg_)) {
+  if (network::poll(this->command_, this->zmq_subscriber_)) {
     this->last_command_ = std::chrono::steady_clock::now();
-    this->control_type_ = this->zmq_command_msg_.controlType;
-
-    this->command_joint_positions_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointPosition.array().data(), 7, 1);
-    this->command_joint_velocities_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointVelocity.array().data(), 7, 1);
-    this->command_joint_torques_ = Eigen::Map<Eigen::MatrixXd>(this->zmq_command_msg_.jointTorque.array().data(), 7, 1);
-
-    this->command_cartesian_position_ = Eigen::Vector3d(this->zmq_command_msg_.eePose.position.array().data());
-    this->command_cartesian_orientation_ = Eigen::Quaterniond(this->zmq_command_msg_.eePose.orientation.array_xyzw().data());
-    this->command_cartesian_twist_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.linear.array().data());
-    this->command_cartesian_twist_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeTwist.angular.array().data());
-    this->command_cartesian_wrench_.block<3, 1>(0, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.linear.array().data());
-    this->command_cartesian_wrench_.block<3, 1>(3, 0) = Eigen::Vector3d(this->zmq_command_msg_.eeWrench.angular.array().data());
   } else if (std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - this->last_command_).count() > this->command_timeout_.count()) {
-    this->command_joint_velocities_.setZero();
-    this->command_joint_torques_.setZero();
-    this->command_cartesian_twist_.setZero();
-    this->command_cartesian_wrench_.setZero();
+    this->reset_command();
   }
 }
 
 void FrankaLightWeightInterface::publish_robot_state() {
-  Eigen::MatrixXd::Map(this->zmq_state_msg_.jointPosition.data.data(), 7, 1) = this->current_joint_positions_.array();
-  Eigen::MatrixXd::Map(this->zmq_state_msg_.jointVelocity.data.data(), 7, 1) = this->current_joint_velocities_.array();
-  Eigen::MatrixXd::Map(this->zmq_state_msg_.jointTorque.data.data(), 7, 1) = this->current_joint_torques_.array();
-
-  Eigen::MatrixXd::Map(this->zmq_state_msg_.jacobian.data(), 6, 7) = this->current_jacobian_.array();
-  Eigen::MatrixXd::Map(this->zmq_state_msg_.mass.data(), 7, 7) = this->current_mass_.array();
-
-  std::array<double, 7> eePose{};
-  Eigen::MatrixXd::Map(&eePose[0], 3, 1) = this->current_cartesian_position_.array();
-  eePose[3] = this->current_cartesian_orientation_.w();
-  Eigen::MatrixXd::Map(&eePose[4], 3, 1) = this->current_cartesian_orientation_.vec().array();
-  this->zmq_state_msg_.eePose = frankalwi::proto::EEPose(eePose);
-
-  std::array<double, 6> eeTwist{};
-  Eigen::MatrixXd::Map(&eeTwist[0], 6, 1) = this->current_cartesian_twist_.array();
-  this->zmq_state_msg_.eeTwist = frankalwi::proto::EETwist(eeTwist);
-
-  Eigen::MatrixXd::Map(&eeTwist[0], 6, 1) = this->current_cartesian_wrench_.array();
-  this->zmq_state_msg_.eeWrench = frankalwi::proto::EETwist(eeTwist);
-
-  send(this->zmq_state_msg_);
+  network::send(this->state_, this->zmq_publisher_);
 }
 
 void FrankaLightWeightInterface::read_robot_state(const franka::RobotState& robot_state) {
   // extract cartesian info
   Eigen::Affine3d eef_transform(Eigen::Matrix4d::Map(robot_state.O_T_EE.data()));
-  this->current_cartesian_position_ = eef_transform.translation();
-  this->current_cartesian_orientation_ = Eigen::Quaterniond(eef_transform.linear());
-  this->current_cartesian_wrench_ =
-      Eigen::VectorXd::Map(robot_state.O_F_ext_hat_K.data(), robot_state.O_F_ext_hat_K.size());
+  this->state_.ee_state.set_pose(eef_transform.translation(), Eigen::Quaterniond(eef_transform.linear()));
+  this->state_.ee_state.set_wrench(Eigen::MatrixXd::Map(robot_state.O_F_ext_hat_K.data(), 6, 1));
 
   // extract joint info
-  this->current_joint_positions_ = Eigen::VectorXd::Map(robot_state.q.data(), robot_state.q.size());
-  this->current_joint_velocities_ = Eigen::VectorXd::Map(robot_state.dq.data(), robot_state.q.size());
-  this->current_joint_torques_ = Eigen::VectorXd::Map(robot_state.tau_J.data(), robot_state.q.size());
+  assert(robot_state.q.size() == 7);
+  this->state_.joint_state.set_positions(Eigen::VectorXd::Map(robot_state.q.data(), 7));
+  this->state_.joint_state.set_velocities(Eigen::VectorXd::Map(robot_state.dq.data(), 7));
+  this->state_.joint_state.set_torques(Eigen::VectorXd::Map(robot_state.tau_J.data(), 7));
 
   // extract jacobian
   std::array<double, 42> jacobian_array = this->franka_model_->zeroJacobian(franka::Frame::kEndEffector, robot_state);
-  this->current_jacobian_ = Eigen::Map<const Eigen::Matrix<double, 6, 7> >(jacobian_array.data());
+  this->state_.jacobian.set_data(Eigen::Map<const Eigen::Matrix<double, 6, 7>>(jacobian_array.data()));
 
   std::array<double, 49> current_mass_array = this->franka_model_->mass(robot_state);
-  this->current_mass_ = Eigen::Map<const Eigen::Matrix<double, 7, 7> >(current_mass_array.data());
+  this->state_.mass = Eigen::Map<const Eigen::Matrix<double, 7, 7> >(current_mass_array.data());
 
   // get the twist from jacobian and current joint velocities
-  this->current_cartesian_twist_ = this->current_jacobian_ * this->current_joint_velocities_;
+  this->state_.ee_state.set_twist(this->state_.jacobian * this->state_.joint_state.get_velocities());
 }
-
 
 void FrankaLightWeightInterface::run_state_publisher() {
   try {
-    this->franka_robot_->read([this](const franka::RobotState& robot_state) {
-      // check the local socket for a command
-      this->poll_external_command();
-      if (this->control_type_ != proto::NONE) {
-        std::cout << "Received a new control type command - switching! " << std::endl;
-        return false;
-      }
-      this->read_robot_state(robot_state);
-      this->publish_robot_state();
-      return true;
-    });
+    this->franka_robot_->read(
+        [this](const franka::RobotState& robot_state) {
+          // check the local socket for a command
+          this->poll_external_command();
+          if (this->command_.control_type != proto::ControlType::NONE) {
+            std::cout << "Received a new control type command - switching! " << std::endl;
+            return false;
+          }
+          this->read_robot_state(robot_state);
+          this->publish_robot_state();
+          return true;
+        });
   } catch (const franka::Exception& e) {
     std::cerr << e.what() << std::endl;
   }
@@ -176,53 +179,53 @@ void FrankaLightWeightInterface::run_state_publisher() {
 
 void FrankaLightWeightInterface::run_joint_torques_controller() {
   // Set additional parameters always before the control loop, NEVER in the control loop!
+
   // Set collision behavior.
   this->franka_robot_->setCollisionBehavior(
-      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
-      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}});
+      this->collision_behaviour_.ltta, this->collision_behaviour_.utta, this->collision_behaviour_.lttn,
+      this->collision_behaviour_.uttn, this->collision_behaviour_.lfta, this->collision_behaviour_.ufta,
+      this->collision_behaviour_.lftn, this->collision_behaviour_.uftn);
 
-  // Damping
+  // Set joint damping.
   Eigen::ArrayXd d_gains = Eigen::ArrayXd(7);
   d_gains << 25.0, 25.0, 25.0, 25.0, 15.0, 15.0, 5.0;
 
   try {
-    this->franka_robot_->control([this, d_gains](const franka::RobotState& robot_state,
-                                                 franka::Duration) -> franka::Torques {
-      // check the local socket for a torque command
-      this->poll_external_command();
+    this->franka_robot_->control(
+        [this, d_gains](
+            const franka::RobotState& robot_state, franka::Duration
+        ) -> franka::Torques {
+          // check the local socket for a torque command
+          this->poll_external_command();
 
-      if (this->control_type_ != proto::JOINT_TORQUE) {
-        throw IncompatibleControlTypeException("Control type changed!");
-      }
+          if (this->command_.control_type != proto::ControlType::JOINT_TORQUE) {
+            throw IncompatibleControlTypeException("Control type changed!");
+          }
 
-      // lock mutex
-      std::lock_guard<std::mutex> lock(this->get_mutex());
-      // extract current state
-      this->read_robot_state(robot_state);
+          // lock mutex
+          std::lock_guard<std::mutex> lock(this->get_mutex());
+          // extract current state
+          this->read_robot_state(robot_state);
 
-      // get the coriolis array
-      std::array<double, 7> coriolis_array = this->franka_model_->coriolis(robot_state);
-      Eigen::Map<const Eigen::Matrix<double, 7, 1> > coriolis(coriolis_array.data());
+          // get the coriolis array
+          std::array<double, 7> coriolis_array = this->franka_model_->coriolis(robot_state);
+          Eigen::Map<const Eigen::Matrix<double, 7, 1> > coriolis(coriolis_array.data());
 
-      // get the mass matrix
-      std::array<double, 49> mass_array = franka_model_->mass(robot_state);
-      Eigen::Map<const Eigen::Matrix<double, 7, 7> > mass(mass_array.data());
+          // get the mass matrix
+          std::array<double, 49> mass_array = franka_model_->mass(robot_state);
+          Eigen::Map<const Eigen::Matrix<double, 7, 7> > mass(mass_array.data());
 
-      std::array<double, 7> torques{};
-      Eigen::VectorXd::Map(&torques[0], 7) = this->command_joint_torques_.array()
-          - d_gains * current_joint_velocities_.array()
-          + coriolis.array();
+          std::array<double, 7> torques{};
+          Eigen::VectorXd::Map(&torques[0], 7) = this->command_.joint_state.get_torques().array()
+              - d_gains * this->state_.joint_state.get_velocities().array() + coriolis.array();
 
-      // write the state out to the local socket
-      this->publish_robot_state();
+          // write the state out to the local socket
+          this->publish_robot_state();
 
-      //return torques;
-      return torques;
-    });
-  }
-  catch (const franka::Exception& e) {
+          //return torques;
+          return torques;
+        });
+  } catch (const franka::Exception& e) {
     std::cerr << e.what() << std::endl;
   }
 }
@@ -230,57 +233,41 @@ void FrankaLightWeightInterface::run_joint_torques_controller() {
 void FrankaLightWeightInterface::run_cartesian_velocities_controller() {
   // Set additional parameters always before the control loop, NEVER in the control loop!
 
-  this->franka_robot_->setCartesianImpedance({{100, 100, 100, 10, 10, 10}});
-
   // Set collision behavior.
   this->franka_robot_->setCollisionBehavior(
-      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-      {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
-      {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}});
+      this->collision_behaviour_.ltta, this->collision_behaviour_.utta, this->collision_behaviour_.lttn,
+      this->collision_behaviour_.uttn, this->collision_behaviour_.lfta, this->collision_behaviour_.ufta,
+      this->collision_behaviour_.lftn, this->collision_behaviour_.uftn);
+
+  // Set carteisan impedance
+  this->franka_robot_->setCartesianImpedance({{100, 100, 100, 10, 10, 10}});
 
   try {
-    this->franka_robot_->control([this](const franka::RobotState& robot_state,
-                                                 franka::Duration) -> franka::CartesianVelocities {
-      // check the local socket for a velocity command
-      this->poll_external_command();
+    this->franka_robot_->control(
+        [this](
+            const franka::RobotState& robot_state, franka::Duration
+        ) -> franka::CartesianVelocities {
+          // check the local socket for a velocity command
+          this->poll_external_command();
 
-      if (this->control_type_ != proto::CARTESIAN_TWIST) {
-        throw IncompatibleControlTypeException("Control type changed!");
-      }
+          if (this->command_.control_type != proto::ControlType::CARTESIAN_TWIST) {
+            throw IncompatibleControlTypeException("Control type changed!");
+          }
 
-      // lock mutex
-      std::lock_guard<std::mutex> lock(this->get_mutex());
-      // extract current state
-      this->read_robot_state(robot_state);
+          // lock mutex
+          std::lock_guard<std::mutex> lock(this->get_mutex());
+          // extract current state
+          this->read_robot_state(robot_state);
 
-      std::array<double, 6> velocities{};
-      Eigen::VectorXd::Map(&velocities[0], 6) = this->command_cartesian_twist_.array();
+          std::array<double, 6> velocities{};
+          Eigen::VectorXd::Map(&velocities[0], 6) = this->command_.ee_state.get_twist();
 
-      // write the state out to the local socket
-      this->publish_robot_state();
-      return velocities;
-    }, franka::ControllerMode::kCartesianImpedance, true, 10.0);
-  }
-  catch (const franka::Exception& e) {
+          // write the state out to the local socket
+          this->publish_robot_state();
+          return velocities;
+        }, franka::ControllerMode::kCartesianImpedance, true, 10.0);
+  } catch (const franka::Exception& e) {
     std::cerr << e.what() << std::endl;
   }
-}
-
-bool FrankaLightWeightInterface::send(const proto::StateMessage<7>& state) {
-  zmq::message_t message(sizeof(state));
-  memcpy(message.data(), &state, sizeof(state));
-  auto res = this->zmq_publisher_.send(message, zmq::send_flags::none);
-
-  return res.has_value();
-}
-
-bool FrankaLightWeightInterface::poll(proto::CommandMessage<7>& command) {
-  zmq::message_t message;
-  auto res = this->zmq_subscriber_.recv(message, zmq::recv_flags::dontwait);
-  if (res) {
-    command = *message.data<proto::CommandMessage<7>>();
-  }
-  return res.has_value();
 }
 }


### PR DESCRIPTION
This is a draft PR just to see and discuss the changes. By refactoring the franka interface to use `clproto`, it opens up a number of useful avenues. For a start,  the internal representation of state and command variables here is greatly simplified (2 objects instead of 19) along with the internal mapping of messages to state and command. But, it will also greatly simply the communication with this interface from external control library users. Those users won't have to duplicate the translation of commands and states each time on their side, since clproto and the simple helper functions take care of it.

I have a docker file and dev server script I used to test this out with CLion, but of course this will stay a draft until it's tested on the robot. I think we can then tag the previous main branch release with some meaningful name, which will allow reverse compatibility for users of the traditional `franka_lwi_communication_protocol.h`.

---

* Define new proto messages for
state and command that use
state_representation types for EE
and joint states.

* Define new encoded messages
that store strings in a structure

* Add encode / decode helper
methods using clproto library

* Add zmq network helper methods
for send and poll

* Refactor FrankaLightWeightInterface
to use state representation types
internally

* Add collision behaviour API